### PR TITLE
Removed minItem limits that were previously unchecked by buggy swagge…

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2645,8 +2645,7 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/newSection"
-                    },
-                    "minItems": 1
+                    }
                 },
                 "questions": {
                     "$ref": "#/definitions/newSurveyQuestions"
@@ -2764,8 +2763,7 @@
             "type": "array",
             "items": {
                 "$ref": "#/definitions/surveyQuestion"
-            },
-            "minItems": 1
+            }
         },
         "survey": {
             "type": "object",
@@ -2798,8 +2796,7 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/section"
-                    },
-                    "minItems": 1
+                    }
                 },
                 "questions": {
                     "$ref": "#/definitions/surveyQuestions"


### PR DESCRIPTION
…r version

#### What's this PR do?

hotfix to remove minLength limits in swagger for questions/sections on a survey. Previously swagger wasn't actually checking the lengths. Should have removed them when we made a change to allow surveys with no questions or sections.

#### Related JIRA tickets:
N/A
#### How should this be manually tested?

create/get empty survey with either no questions or no sections

#### Any background context you want to provide?

currently blocking indaba
#### Screenshots (if appropriate):