### PR TITLE
Bug/SER-168 Read jwt secret environment variable in development config

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -2,6 +2,6 @@
 
 module.exports = {
     jwt: {
-        secret: '0a6b944d-d2fb-46fc-a85e-0295c986cd9f',
+        secret: process.env.SURVEY_SERVICE_CLIENT_SECRET || '0a6b944d-d2fb-46fc-a85e-0295c986cd9f',
     },
 };


### PR DESCRIPTION
#### What's this PR do?
Adds support for specifying a jwt secret in development mode. Previously the value in the environment variable was being clobbered by a hard-coded default value.

#### Related JIRA tickets:
[SER-168](https://jira.amida-tech.com/browse/SER-168)

#### How should this be manually tested?
1. Set the `SURVEY_SERVICE_CLIENT_SECRET` environment variable to the value used by the jwt token generator (auth service).
1. Make an authenticated call to the survey service with a token that was generated by the auth service with the same secret
1. Check that the call succeeds
1. Change the `SURVEY_SERVICE_CLIENT_SECRET` environment variable and restart the survey service.
1. Make an authenticated call with the same token as before
1. Check that the call does NOT succeed because of authentication failure.

#### Any background context you want to provide?
#### Screenshots (if appropriate):